### PR TITLE
Adding caching for organizations endpoint and ingesting export tokens.

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -35,3 +35,14 @@ The process for generating an Account Key is as follows:
    template, create a new .env file
 5. Use your generated **Account API Key** in the **ACCOUNT_API_KEY** field in
    the .env file
+
+You'll need to generate an **Export Token** for each organization whose assets,
+services, and wireless data you want to include in the graph. The integration
+will automatically collect these tokens if they are present. Organizations
+without export tokens will not have assets, services, or wireless data ingested.
+
+1. Navigate to the [Rumble Console](https://console.rumble/run)
+2. In the navigation bar, go to `Organizations`
+3. Click on the organization in which you want to create an `Export Token`
+4. Press the **Generate Export Token** button.
+5. Repeat for all organizations whose data you want to ingest.

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -19,16 +19,17 @@
 
 ## Requirements
 
-<!--
-TODO: Only export token for assets a possibility
-TODO: Organization Admin for org admin vs account admin
--->
-
 - JupiterOne integration requires a Rumble **Account API Key**. To generate an
   **Account API Key** you'll need:
 
   - Rumble Enterprise License
   - Administrator access
+
+- JupiterOne integration also requires an **Export Token** for each organization
+  whose asset, services, and wireless data you want to include. To generate an
+  **Export Token** you'll need:
+
+  -
 
 - You must have permission in JupiterOne to install new integrations.
 
@@ -40,16 +41,32 @@ If you need help with this integration, please contact
 ## Integration Walkthrough
 
 You'll need an **Account API Key** and administrator access to the account to
-integrate with JupiterOne.
+integrate with JupiterOne. You'll also need to generate **Export Tokens** for
+all organizations whose data you want to ingest.
 
 ### In Rumble
 
+**Account API Key Generation**
+
 1. Navigate to the [Rumble Console](https://console.rumble.run/).
-2. In the navigation bar, go to Account
+2. In the navigation bar, go to `Account`
 3. On the Account page under the Account API keys section, click "Generate API
    Key"
 4. A new **Account API Key** will be created. This key will be used in the next
    section.
+
+**Export Token Generation**
+
+You'll need to generate an export token for each organization whose assets,
+services, and wireless data you want to include in the graph. The integration
+will automatically collect these tokens if they are present. Organizations
+without export tokens will not have assets, services, or wireless data ingested.
+
+1. Navigate to the [Rumble Console](https://console.rumble/run)
+2. In the navigation bar, go to `Organizations`
+3. Click on the organization in which you want to create an `Export Token`
+4. Press the **Generate Export Token** button.
+5. Repeat for all organizations whosse data you want to ingest.
 
 ### In JupiterOne
 

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -29,7 +29,8 @@
   whose asset, services, and wireless data you want to include. To generate an
   **Export Token** you'll need:
 
-  -
+  - Admin access to the organization for which you want to generate an **Export
+    Token**
 
 - You must have permission in JupiterOne to install new integrations.
 

--- a/src/__recordings__/get-keys-collects-data_1107443385/recording.har
+++ b/src/__recordings__/get-keys-collects-data_1107443385/recording.har
@@ -1,0 +1,153 @@
+{
+  "log": {
+    "_recordingName": "get-keys-collects-data",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "5.1.1"
+    },
+    "entries": [
+      {
+        "_id": "63d6246173e109534a20ab144b779f3c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "user-agent",
+              "value": "got (https://github.com/sindresorhus/got)"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "console.rumble.run"
+            }
+          ],
+          "headersSize": 262,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://console.rumble.run/api/v1.0/account/orgs"
+        },
+        "response": {
+          "bodySize": 2753,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2753,
+            "text": "[{\"id\":\"dc2f89e1-f698-43cd-b40f-bcfd59b7c006\",\"created_at\":1644261959,\"created_by\":\"matthew.zember@jupiterone.com\",\"updated_at\":1644265342,\"client_id\":\"a72b7a35-d1d0-4aec-890f-7c8d8a580cf4\",\"download_token\":\"[REDACTED]\",\"download_token_created_at\":1644265342,\"demo\":false,\"project\":false,\"parent_id\":\"e4d3fbeb-5158-4d7b-b203-a87f2c3dd7cb\",\"name\":\"JupiterOneSubOrg\",\"description\":\"\",\"inactive\":false,\"deactivated_at\":0,\"service_count\":0,\"service_count_tcp\":0,\"service_count_udp\":0,\"service_count_arp\":0,\"service_count_icmp\":0,\"asset_count\":0,\"live_asset_count\":0,\"recent_asset_count\":0,\"export_token\":\"[REDACTED]\",\"export_token_created_at\":1644262369,\"export_token_last_used_at\":0,\"export_token_last_used_by\":\"\",\"export_token_counter\":0,\"expiration_assets_stale\":5,\"expiration_assets_offline\":5,\"expiration_scans\":365,\"expiration_warning_last_sent\":0},{\"id\":\"e4d3fbeb-5158-4d7b-b203-a87f2c3dd7cb\",\"created_at\":1642795485,\"created_by\":\"\",\"updated_at\":1645714218,\"client_id\":\"a72b7a35-d1d0-4aec-890f-7c8d8a580cf4\",\"download_token\":\"[REDACTED]\",\"download_token_created_at\":1642795485,\"demo\":false,\"project\":false,\"parent_id\":\"00000000-0000-0000-0000-000000000000\",\"name\":\"JupiterOne\",\"description\":null,\"inactive\":false,\"deactivated_at\":0,\"service_count\":48,\"service_count_tcp\":20,\"service_count_udp\":13,\"service_count_arp\":8,\"service_count_icmp\":7,\"asset_count\":8,\"live_asset_count\":8,\"recent_asset_count\":8,\"export_token\":\"\",\"export_token_created_at\":0,\"export_token_last_used_at\":0,\"export_token_last_used_by\":\"\",\"export_token_counter\":0,\"expiration_assets_stale\":0,\"expiration_assets_offline\":0,\"expiration_scans\":365,\"expiration_warning_last_sent\":0},{\"id\":\"463fed64-54bf-4369-b4b4-86a039773470\",\"created_at\":1642795486,\"created_by\":\"\",\"updated_at\":1645117093,\"client_id\":\"a72b7a35-d1d0-4aec-890f-7c8d8a580cf4\",\"download_token\":\"[REDACTED]\",\"download_token_created_at\":1642795486,\"demo\":true,\"project\":false,\"parent_id\":\"00000000-0000-0000-0000-000000000000\",\"name\":\"Demo Organization\",\"description\":\"This is a demo organization populated using sample data from the Rumble Test Lab. This organization does not count against your license limits and may be removed as needed.\",\"inactive\":false,\"deactivated_at\":0,\"service_count\":380,\"service_count_tcp\":198,\"service_count_udp\":83,\"service_count_arp\":45,\"service_count_icmp\":50,\"asset_count\":52,\"live_asset_count\":52,\"recent_asset_count\":0,\"export_token\":\"[REDACTED]\",\"export_token_created_at\":1645117093,\"export_token_last_used_at\":0,\"export_token_last_used_by\":\"\",\"export_token_counter\":0,\"expiration_assets_stale\":0,\"expiration_assets_offline\":0,\"expiration_scans\":0,\"expiration_warning_last_sent\":0}]"
+          },
+          "cookies": [
+            {
+              "expires": "2022-03-03T19:35:36.000Z",
+              "httpOnly": true,
+              "maxAge": 604800,
+              "name": "__Secure-RS",
+              "path": "/",
+              "sameSite": "Lax",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 24 Feb 2022 19:35:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://ssl.google-analytics.com https://js.stripe.com https://plausible.io; style-src 'self' 'unsafe-inline'; font-src 'self' https://*.rumble.run data:; img-src 'self' https://*.rumble.run https://www.googletagmanager.com https://www.google-analytics.com https://ssl.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com https://*.gravatar.com https://*.amazonaws.com data: https://console.rumble.run; report-uri https://console.rumble.run/csp/report;"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "report-to",
+              "value": "{ \"group\": \"console\",  \"max-age\": 10886400,  \"endpoints\": [{\"url\": \"https://console.rumble.run/csp/report\" }] }"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-api-usage-limit",
+              "value": "5000"
+            },
+            {
+              "name": "x-api-usage-remaining",
+              "value": "4997"
+            },
+            {
+              "name": "x-api-usage-today",
+              "value": "3"
+            },
+            {
+              "name": "x-api-usage-total",
+              "value": "437"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            }
+          ],
+          "headersSize": 1427,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-02-24T19:35:36.618Z",
+        "time": 150,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 150
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/__recordings__/logger-warns-missing-keys_3968992191/recording.har
+++ b/src/__recordings__/logger-warns-missing-keys_3968992191/recording.har
@@ -1,0 +1,153 @@
+{
+  "log": {
+    "_recordingName": "logger-warns-missing-keys",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "5.1.1"
+    },
+    "entries": [
+      {
+        "_id": "63d6246173e109534a20ab144b779f3c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "user-agent",
+              "value": "got (https://github.com/sindresorhus/got)"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "console.rumble.run"
+            }
+          ],
+          "headersSize": 262,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://console.rumble.run/api/v1.0/account/orgs"
+        },
+        "response": {
+          "bodySize": 2753,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2753,
+            "text": "[{\"id\":\"dc2f89e1-f698-43cd-b40f-bcfd59b7c006\",\"created_at\":1644261959,\"created_by\":\"matthew.zember@jupiterone.com\",\"updated_at\":1644265342,\"client_id\":\"a72b7a35-d1d0-4aec-890f-7c8d8a580cf4\",\"download_token\":\"[REDACTED]\",\"download_token_created_at\":1644265342,\"demo\":false,\"project\":false,\"parent_id\":\"e4d3fbeb-5158-4d7b-b203-a87f2c3dd7cb\",\"name\":\"JupiterOneSubOrg\",\"description\":\"\",\"inactive\":false,\"deactivated_at\":0,\"service_count\":0,\"service_count_tcp\":0,\"service_count_udp\":0,\"service_count_arp\":0,\"service_count_icmp\":0,\"asset_count\":0,\"live_asset_count\":0,\"recent_asset_count\":0,\"export_token\":\"[REDACTED]\",\"export_token_created_at\":1644262369,\"export_token_last_used_at\":0,\"export_token_last_used_by\":\"\",\"export_token_counter\":0,\"expiration_assets_stale\":5,\"expiration_assets_offline\":5,\"expiration_scans\":365,\"expiration_warning_last_sent\":0},{\"id\":\"e4d3fbeb-5158-4d7b-b203-a87f2c3dd7cb\",\"created_at\":1642795485,\"created_by\":\"\",\"updated_at\":1645714218,\"client_id\":\"a72b7a35-d1d0-4aec-890f-7c8d8a580cf4\",\"download_token\":\"[REDACTED]\",\"download_token_created_at\":1642795485,\"demo\":false,\"project\":false,\"parent_id\":\"00000000-0000-0000-0000-000000000000\",\"name\":\"JupiterOne\",\"description\":null,\"inactive\":false,\"deactivated_at\":0,\"service_count\":48,\"service_count_tcp\":20,\"service_count_udp\":13,\"service_count_arp\":8,\"service_count_icmp\":7,\"asset_count\":8,\"live_asset_count\":8,\"recent_asset_count\":8,\"export_token\":\"\",\"export_token_created_at\":0,\"export_token_last_used_at\":0,\"export_token_last_used_by\":\"\",\"export_token_counter\":0,\"expiration_assets_stale\":0,\"expiration_assets_offline\":0,\"expiration_scans\":365,\"expiration_warning_last_sent\":0},{\"id\":\"463fed64-54bf-4369-b4b4-86a039773470\",\"created_at\":1642795486,\"created_by\":\"\",\"updated_at\":1645117093,\"client_id\":\"a72b7a35-d1d0-4aec-890f-7c8d8a580cf4\",\"download_token\":\"[REDACTED]\",\"download_token_created_at\":1642795486,\"demo\":true,\"project\":false,\"parent_id\":\"00000000-0000-0000-0000-000000000000\",\"name\":\"Demo Organization\",\"description\":\"This is a demo organization populated using sample data from the Rumble Test Lab. This organization does not count against your license limits and may be removed as needed.\",\"inactive\":false,\"deactivated_at\":0,\"service_count\":380,\"service_count_tcp\":198,\"service_count_udp\":83,\"service_count_arp\":45,\"service_count_icmp\":50,\"asset_count\":52,\"live_asset_count\":52,\"recent_asset_count\":0,\"export_token\":\"[REDACTED]\",\"export_token_created_at\":1645117093,\"export_token_last_used_at\":0,\"export_token_last_used_by\":\"\",\"export_token_counter\":0,\"expiration_assets_stale\":0,\"expiration_assets_offline\":0,\"expiration_scans\":0,\"expiration_warning_last_sent\":0}]"
+          },
+          "cookies": [
+            {
+              "expires": "2022-03-03T19:35:36.000Z",
+              "httpOnly": true,
+              "maxAge": 604800,
+              "name": "__Secure-RS",
+              "path": "/",
+              "sameSite": "Lax",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 24 Feb 2022 19:35:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://ssl.google-analytics.com https://js.stripe.com https://plausible.io; style-src 'self' 'unsafe-inline'; font-src 'self' https://*.rumble.run data:; img-src 'self' https://*.rumble.run https://www.googletagmanager.com https://www.google-analytics.com https://ssl.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com https://*.gravatar.com https://*.amazonaws.com data: https://console.rumble.run; report-uri https://console.rumble.run/csp/report;"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "report-to",
+              "value": "{ \"group\": \"console\",  \"max-age\": 10886400,  \"endpoints\": [{\"url\": \"https://console.rumble.run/csp/report\" }] }"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-api-usage-limit",
+              "value": "5000"
+            },
+            {
+              "name": "x-api-usage-remaining",
+              "value": "4996"
+            },
+            {
+              "name": "x-api-usage-today",
+              "value": "4"
+            },
+            {
+              "name": "x-api-usage-total",
+              "value": "438"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            }
+          ],
+          "headersSize": 1427,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-02-24T19:35:36.783Z",
+        "time": 88,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 88
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,0 +1,59 @@
+import {
+  createMockExecutionContext,
+  createMockIntegrationLogger,
+  Recording,
+} from '@jupiterone/integration-sdk-testing';
+import { integrationConfig } from '../test/config';
+import { setupRumbleRecording } from '../test/recording';
+import { createAPIClient } from './client';
+import { IntegrationConfig } from './config';
+
+describe('apiClient', () => {
+  let recording: Recording;
+  afterEach(async () => {
+    await recording.stop();
+  });
+
+  describe('#getExportTokens', () => {
+    test('successfully gets export tokens', async () => {
+      recording = setupRumbleRecording({
+        directory: __dirname,
+        name: 'get-keys-collects-data',
+      });
+
+      const executionContext = createMockExecutionContext<IntegrationConfig>({
+        instanceConfig: integrationConfig,
+      });
+
+      const apiClient = createAPIClient({
+        config: executionContext.instance.config,
+        logger: executionContext.logger,
+        name: executionContext.instance.name,
+      });
+      const keys = await apiClient.getExportTokens();
+      expect(keys.length).toBeGreaterThan(0);
+    });
+
+    test('logs warning for missing keys', async () => {
+      recording = setupRumbleRecording({
+        directory: __dirname,
+        name: 'logger-warns-missing-keys',
+      });
+
+      const executionContext = createMockExecutionContext<IntegrationConfig>({
+        instanceConfig: integrationConfig,
+      });
+
+      const mockLogger = createMockIntegrationLogger();
+      mockLogger.warn = jest.fn();
+
+      const apiClient = createAPIClient({
+        config: executionContext.instance.config,
+        logger: mockLogger,
+        name: executionContext.instance.name,
+      });
+      await apiClient.getExportTokens();
+      expect(mockLogger.warn).toBeCalled();
+    });
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -31,7 +31,7 @@ export class APIClient {
    * Since there are several calls made to /account/orgs
    * it is worth caching the results
    */
-  orgCache: { [key: string]: any } = {};
+  orgCache: { [key: string]: RumbleOrganization[] } = {};
 
   public async verifyAuthentication(): Promise<void> {
     try {

--- a/src/client.ts
+++ b/src/client.ts
@@ -133,7 +133,7 @@ export class APIClient {
     const tokens: string[] = [];
     for (const org of organizations) {
       // check if the token is empty string or null
-      if (!org.export_token) {
+      if (org.export_token) {
         tokens.push(org.export_token);
       } else {
         this.options.logger.warn(

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,4 +56,7 @@ export async function validateInvocation(
   });
 
   await apiClient.verifyAuthentication();
+  // exportTokens is ingested from the API and needed to retrieve
+  // assets, services, and wireless entities for an organization
+  config.exportTokens = await apiClient.getExportTokens();
 }


### PR DESCRIPTION
# Description

Adding caching for `/account/orgs` endpoint and ingesting `Export Tokens` for use in future steps.

## Summary

### Cache Addition
This PR adds `orgCache` to the `APIClient`. Data from the `/account/orgs` endpoint is used in `verifyAuthentication`, `getExportTokens`, `getAccount`, and `getOrganizations`. To avoid calling this endpoint several times, the first response will be cached. At this time there is not need to expand caching to other parts of the client.

### Export Token Ingestion
The PR also ingests `Export Tokens`. These tokens are needed to access organization specific data from the `/export` API. `Export Tokens` are added to the config as the last step in `validateInvocation`. I chose to bring in the tokens at this point and not later because I thought that after `validateInvocation` we should know what the graph will and will not be able to ingest because of authorization. This will also allow future steps like `fetch-asset`, `fetch-services` and `fetch-wireless` to not have dependencies on the `organization` or `account` steps.

### Documentation Updates

Documentation in `jupiterone.md` and `development.md` has been updated with new instructions about generating `Export Tokens`.

## Type of change

Please leave any irrelevant options unchecked.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [X] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [ ] My changes properly paginate the target service provider's API
  - not available for Rumble API
- [ ] My changes properly handle rate limiting of the target service provider's
      API
  - not implemented yet
- [X] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [X] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [X] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
