### PR TITLE
Removing subnet property from site entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Removed
+
+- Subnet property from site to fix bug
+
 [1.1.0] - 2022-02-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 ### Removed
 
-- Subnet property from site to fix bug
+- Subnet property removed from `Site` entity to fix error when ingesting objects
 
 [1.1.0] - 2022-02-24
 

--- a/src/steps/sites/converter.ts
+++ b/src/steps/sites/converter.ts
@@ -1,5 +1,4 @@
 import {
-  convertProperties,
   createIntegrationEntity,
   Entity,
   parseTimePropertyValue,
@@ -31,9 +30,6 @@ export function createSiteEntity(site: RumbleSite): Entity {
         serviceCountARP: site.service_count_arp,
         serviceCountICMP: site.service_count_icmp,
         assetCount: site.asset_count,
-        subnets: convertProperties(site.subnets, {
-          stringifyObject: true,
-        }),
         assetAddressCount: site.asset_address_count,
         lastTaskId: site.last_task_id ?? undefined,
         lastTaskAt: parseTimePropertyValue(site.last_task_at),


### PR DESCRIPTION
# Description

Removing `subnet` property from `Site` entity to resolve  `OBJECTS_NOT_ALLOWED` error.
